### PR TITLE
Allow resolving of pagerduty alerts, along with bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Required:
 - `description`: Static text of alert to send
 
 Optional:
-- `incident_key`: Provides an incident key that can be used to dedupe alerts
+- `incident_key`: Provides an incident key that can be used to dedupe alerts. Defaults to `<pipeline-name>/<job-name
+- `action`: Specifies whether to `trigger`, `resolve`, or `acknowledge` an insident. Defaults to `trigger`
 
 Example
 -------

--- a/assets/pd_notification.sh
+++ b/assets/pd_notification.sh
@@ -1,17 +1,25 @@
 #!/bin/bash
-set -ue
+set -e
 
 # for jq
 PATH=/usr/local/bin:$PATH
 
 if [ "${SMUGGLER_service_key}" = "" ]; then
-  echo 'service_key must be set on source'
+  echo 'service_key must be set on source' >&2
   exit 1
 fi
 if [ "${SMUGGLER_description}" = "" ]; then
-  echo 'description must be set on params'
+  echo 'description must be set on params' >&2
   exit 1
 fi
+if [[ -z ${SMUGGLER_action} ]]; then
+  SMUGGLER_action="trigger"
+fi
+if [[ -z ${SMUGGLER_incident_key} ]]; then
+  SMUGGLER_incident_key="${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME}"
+fi
+
+set -u
 
 SMUGGLER_atc_external_url=${SMUGGLER_atc_external_url:-${ATC_EXTERNAL_URL}}
 error_context="No error context possible without valid ATC url and credentials."
@@ -29,17 +37,18 @@ data="$(
 jq -n \
   --arg description "${SMUGGLER_description}" \
   --arg service_key "${SMUGGLER_service_key}" \
-  --arg incident_key "${BUILD_PIPELINE_NAME}/${BUILD_JOB_NAME}" \
+  --arg incident_key "${SMUGGLER_incident_key}" \
+  --arg action "${SMUGGLER_action}" \
   --arg output "${error_context}" \
   --arg concourse_build_url "${concourse_build_url}" \
   --arg pipeline_name "${BUILD_PIPELINE_NAME}" \
   --arg job_name "${BUILD_JOB_NAME}" \
   '
     {
-      "event_type": "trigger",
+      "event_type": $action,
       "service_key": $service_key,
       "description": $description,
-      "incident_key": $concourse_build_url,
+      "incident_key": $incident_key,
       "client": "concourse",
       "client_url": $concourse_build_url,
       "details": {
@@ -63,8 +72,8 @@ response=$(curl -s \
 status=$(echo "$response" | jq -r '.status // ""')
 incident_key=$(echo "$response" | jq -r '.incident_key // ""')
 if [ "$status" != "success" ]; then
-  echo "Alerting to pagerduty failed"
-  echo $response
+  echo "Alerting to pagerduty failed" >&2
+  echo $response >&2
   exit 1
 fi
 

--- a/assets/pd_notification.sh
+++ b/assets/pd_notification.sh
@@ -77,4 +77,4 @@ if [ "$status" != "success" ]; then
   exit 1
 fi
 
-echo "{\"version\": {\"ref\": \"${SMUGGLER_service_key}\"},\"metadata\":[${response}]}"
+echo "{\"version\": {\"ref\": \"${SMUGGLER_incident_key}\"},\"metadata\":[${response}]}"


### PR DESCRIPTION
Allow users to specify the event type and incident_key
This adds a new param for the event `action`, which controls
whether an alert will be triggered, resolved, or acknowledged
based on the event. Should allow users to create `on_success` events
which auto-resolve incidents that were created by the pipeline's
`on_failure` event.

This also fixes a bug where the optional incident_key param was
ignored, defaulting it to what used to be forced on the event.

Also fixed are issues where problems connecting to pagerduty would
trigger non-json output from the resource, resulting in Concourse errors.

Additionally, incident key is now reported as the concourse version/ref, not the pagerduty service key. I believe the incident key used to be used for this before the switch to smuggler.