### PR TITLE
We are not using incident_key from the response anywhere.

### DIFF
--- a/assets/pd_notification.sh
+++ b/assets/pd_notification.sh
@@ -70,7 +70,6 @@ response=$(curl -s \
   "https://events.pagerduty.com/generic/2010-04-15/create_event.json")
 
 status=$(echo "$response" | jq -r '.status // ""')
-incident_key=$(echo "$response" | jq -r '.incident_key // ""')
 if [ "$status" != "success" ]; then
   echo "Alerting to pagerduty failed" >&2
   echo $response >&2


### PR DESCRIPTION
Shellcheck correctly told me that line 73 where we are setting incident_key from the curl response is not being used anywhere, so I'm removing it as it is a waste of bytes and cpu cycles just sitting there doing nothing worthwhile.